### PR TITLE
updating regex for http git urls, adding tests for user/tokens and ge…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <scm>
+        <connection>scm:git:https://github.com/WASdev/intoto4j.git</connection>
+        <developerConnection>scm:git:https://github.com/WASdev/intoto4j.git</developerConnection>
+        <url>https://github.com/WASdev/intoto4j</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <groupId>com.ibm.websphere.appserver.features</groupId>
     <artifactId>intoto4j</artifactId>
     <version>3.0.2-SNAPSHOT</version>
@@ -40,6 +47,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.scm.id>github</project.scm.id>
     </properties>
 
     <dependencies>
@@ -125,6 +133,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
@@ -146,6 +155,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <goals>deploy</goals>
+                </configuration>
+                <version>3.1.1</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/ibm/intoto/attestation/utils/GitUtils.java
+++ b/src/main/java/com/ibm/intoto/attestation/utils/GitUtils.java
@@ -37,7 +37,7 @@ public class GitUtils {
     /**
      * Regex Pattern for extracting the owner and repositiory name from a Git remote URL in the format https://github.com/<owner>/<repo-name>.git
      */
-    public static final Pattern GIT_REPO_OWNER_AND_NAME_PATTERN_HTTP = Pattern.compile("^https?://(www.)?github.(ibm.)?com/(?<" + REGEX_GROUP_NAME_OWNER + ">[^\\/]+)\\/(?<" + REGEX_GROUP_NAME_REPO_NAME + ">.+).git$", Pattern.CASE_INSENSITIVE);
+    public static final Pattern GIT_REPO_OWNER_AND_NAME_PATTERN_HTTP = Pattern.compile("^https?://(?:[^@]+@)?(www.)?github.(ibm.)?com/(?<" + REGEX_GROUP_NAME_OWNER + ">[^\\/]+)\\/(?<" + REGEX_GROUP_NAME_REPO_NAME + ">.+).git$", Pattern.CASE_INSENSITIVE);
 
     public static final String GITHUB_REPO_URL_FORMAT = "https://github.com/%s/%s";
 

--- a/src/test/java/com/ibm/intoto/attestation/custom/resource/descriptors/git/GitRepositoryResourceDescriptorTest.java
+++ b/src/test/java/com/ibm/intoto/attestation/custom/resource/descriptors/git/GitRepositoryResourceDescriptorTest.java
@@ -174,4 +174,72 @@ public class GitRepositoryResourceDescriptorTest {
         }
     }
 
+    @Test
+    public void test_refWithHttpGitRepoUrlUsingUsernameAndToken() {
+        final String repoUrl = "https://gitclientuser:ghd_AZTjAqHeRgitclienttokenS86VDZCA2ptGcA@github.com/" + user + "/" + repoName +".git";
+        final String expectedGitRepoUri = "https://github.com/" + user + "/" + repoName;
+        final String ref = "refs/heads/main";
+        try {
+            GitRepositoryResourceDescriptor.Builder builder = new GitRepositoryResourceDescriptor.Builder(repoUrl);
+            builder.ref(ref);
+            GitRepositoryResourceDescriptor descriptor = builder.build();
+
+            assertEquals(repoUrl, descriptor.getGitRepoUrl(), "Git repo URL did not match expected value.");
+            assertEquals(ref, descriptor.getRef(), "Ref did not match the expected value.");
+            assertEquals(expectedGitRepoUri, descriptor.getUri(), "URI did not match the expected value.");
+
+            DigestSet digest = descriptor.getDigest();
+            assertNotNull(digest, "Digest set should not have been null but was.");
+            JsonObject digestJson = digest.build();
+            assertTrue(digestJson.isEmpty(), "Digest set should have been empty but was: " + digestJson);
+
+            assertNull(descriptor.getName(), "Name should have been null but was: " + descriptor.getName());
+            assertNull(descriptor.getContent(), "Content should have been null but was: " + descriptor.getContent());
+            assertNull(descriptor.getDownloadLocation(), "Download location should have been null but was: " + descriptor.getDownloadLocation());
+            assertNull(descriptor.getMediaType(), "Media type should have been null but was: " + descriptor.getMediaType());
+            assertNull(descriptor.getAnnotations(), "Annotations should have been null but were: " + descriptor.getAnnotations());
+
+            JsonObject descriptorJson = descriptor.toJson();
+            testUtils.assertJsonContainsOnlyExpectedStringEntry("GitRepositoryResourceDescriptor", descriptorJson, ResourceDescriptor.KEY_URI, expectedGitRepoUri);
+        } catch (Exception e) {
+            fail("Encountered unexpected exception: " + e);
+        }
+    }
+
+    @Test
+    public void test_refWithHttpsGitRepoUrl() {
+        final String repoUrl = "https://github.com/" + user + "/" + repoName +".git";
+        final String expectedGitRepoUri = "https://github.com/" + user + "/" + repoName;
+        final String ref = "refs/heads/main";
+        try {
+            GitRepositoryResourceDescriptor.Builder builder = new GitRepositoryResourceDescriptor.Builder(repoUrl);
+            builder.ref(ref);
+            GitRepositoryResourceDescriptor descriptor = builder.build();
+
+            assertEquals(repoUrl, descriptor.getGitRepoUrl(), "Git repo URL did not match expected value.");
+            assertEquals(ref, descriptor.getRef(), "Ref did not match the expected value.");
+            assertEquals(expectedGitRepoUri, descriptor.getUri(), "URI did not match the expected value.");
+        } catch (Exception e) {
+            fail("Encountered unexpected exception: " + e);
+        }
+    }
+    @Test
+    public void test_refWithHttpIbmGitRepoUrl() {
+        final String repoUrl = "http://github.ibm.com/" + user + "/" + repoName +".git";
+        final String expectedGitRepoUri = "https://github.com/" + user + "/" + repoName;
+        final String ref = "refs/heads/main";
+        try {
+            GitRepositoryResourceDescriptor.Builder builder = new GitRepositoryResourceDescriptor.Builder(repoUrl);
+            builder.ref(ref);
+            GitRepositoryResourceDescriptor descriptor = builder.build();
+
+            assertEquals(repoUrl, descriptor.getGitRepoUrl(), "Git repo URL did not match expected value.");
+            assertEquals(ref, descriptor.getRef(), "Ref did not match the expected value.");
+            assertEquals(expectedGitRepoUri, descriptor.getUri(), "URI did not match the expected value.");
+        } catch (Exception e) {
+            fail("Encountered unexpected exception: " + e);
+        }
+    }
+    
+
 }


### PR DESCRIPTION
…neric urls and updating pom.xml so we can use the mvn release plugin

adding another test using github.ibm.com and http instead of https

adding `(?:[^@]+@)?` will create a non capturing group which matches all symbols until the first literal `@` between the http(s) protocol and the domain. 

Fixes https://github.com/WASdev/intoto4j/issues/10